### PR TITLE
slightly changed log() so that printf-style interpolation works.

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,10 +1,11 @@
 var colors = require('./colors');
 var date = require('./date');
+var format = require('util').format;
 
 module.exports = function(){
   var time = '['+colors.grey(date(new Date(), 'HH:MM:ss'))+']';
   var args = Array.prototype.slice.call(arguments);
-  args.unshift(time);
+  args[0] = format("%s %s", time, args[0]);
   console.log.apply(console, args);
   return this;
 };

--- a/test/log.js
+++ b/test/log.js
@@ -4,21 +4,38 @@ var path = require('path');
 require('mocha');
 
 describe('log()', function(){
-  it('should work i guess', function(done){
-    var writtenValue;
+
+  var writtenValue, stdout_write, time;
+
+  var emulateLogged = function(time, str) {
+    return '[' + util.colors.grey(time) + '] '+str+'\n'
+  }
+
+  beforeEach(function() {
+    // console.log("in before");
+    time = util.date(new Date(), 'HH:MM:ss');
 
     // Stub process.stdout.write
-    var stdout_write = process.stdout.write;
+    stdout_write = process.stdout.write;
     process.stdout.write = function(value) {
       writtenValue = value;
     };
+  });
 
+  it('should work i guess', function(done){
     util.log(1, 2, 3, 4, 'five');
-    var time = util.date(new Date(), 'HH:MM:ss');
-    writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 2 3 4 five\n');
+    writtenValue.should.eql(emulateLogged(time, '1 2 3 4 five'));
 
     // Restore process.stdout.write
     process.stdout.write = stdout_write;
+    done();
+  });
+
+  it('should interpolate sprintf characters', function(done) {
+    util.log("%s", 'hello');
+    writtenValue.should.eql(emulateLogged(time, 'hello'));
+    process.stdout.write = stdout_write;
+    // console.log('after', writtenValue);
     done();
   });
 });


### PR DESCRIPTION
I noticed if I do something like:

`gutil.log('some number: %d', 42)`

...that gulp-util's log() method doesn't work quite the same as console.log - the interpolation doesn't happen. This is because the time prefix added gets unshifted onto the front of the array that is passed to console.log.apply(). This change combines the time string and the first argument into a single string so we preserve console.log's ability to do interpolation.

Aside: I added a beforeEach hook in the tests to reduce boilerplate code in `test/log.js`.
